### PR TITLE
Fix behaviors for msgpack

### DIFF
--- a/lib/grntest/error.rb
+++ b/lib/grntest/error.rb
@@ -33,6 +33,7 @@ module Grntest
       @type = type
       @content = content
       @reason = reason
+      content = content.inspect if type == "msgpack"
       super("failed to parse <#{@type}> content: #{reason}: <#{content}>")
     end
   end

--- a/lib/grntest/executors/base-executor.rb
+++ b/lib/grntest/executors/base-executor.rb
@@ -390,6 +390,7 @@ module Grntest
 
       def extract_command_info(command)
         @current_command = command
+        @orig_output_type = command[:output_type]
         if @current_command.name == "dump"
           @output_type = "groonga-command"
         else
@@ -585,7 +586,9 @@ module Grntest
           relative_elapsed_time = "000000000000000"
           command = statistic.command
           if command
-            command[:output_type] = nil if command.output_type == :json
+            if command.output_type == :json or @orig_output_type.nil?
+              command[:output_type] = nil
+            end
             log_query("\#>#{command.to_command_format}")
           end
           statistic.each_operation do |operation|

--- a/lib/grntest/executors/http-executor.rb
+++ b/lib/grntest/executors/http-executor.rb
@@ -29,6 +29,10 @@ module Grntest
       end
 
       def send_command(command)
+        if @output_type == 'msgpack'
+          command[:output_type] = 'msgpack'
+        end
+
         if command.name == "load"
           send_load_command(command)
         else
@@ -103,7 +107,7 @@ module Grntest
       end
 
       def normalize_response_data(command, raw_response_data)
-        if raw_response_data.empty? or command.output_type == :none
+        if raw_response_data.empty? or command.output_type == :none or @output_type == "msgpack"
           raw_response_data
         else
           "#{raw_response_data}\n"

--- a/lib/grntest/executors/standard-io-executor.rb
+++ b/lib/grntest/executors/standard-io-executor.rb
@@ -57,7 +57,8 @@ module Grntest
         if may_slow_command?(command)
           options[:first_timeout] = @long_read_timeout
         end
-        read_all_readable_content(@output, options)
+        content = read_all_readable_content(@output, options)
+        @output_type == "msgpack" ? content.sub(/\n\z/, '') : content
       end
 
       MAY_SLOW_COMMANDS = [

--- a/lib/grntest/response-parser.rb
+++ b/lib/grntest/response-parser.rb
@@ -36,7 +36,7 @@ module Grntest
     def parse(content)
       case @type
       when "json", "msgpack"
-        parse_result(content.chomp)
+        parse_result(content)
       else
         content
       end
@@ -46,14 +46,14 @@ module Grntest
       case @type
       when "json"
         begin
-          JSON.parse(result)
+          JSON.parse(result.chomp)
         rescue JSON::ParserError
           raise ParseError.new(@type, result, $!.message)
         end
       when "msgpack"
         begin
-          MessagePack.unpack(result.chomp)
-        rescue MessagePack::UnpackError, NoMemoryError
+          MessagePack.unpack(result)
+        rescue MessagePack::UnpackError, NoMemoryError, EOFError, ArgumentError
           raise ParseError.new(@type, result, $!.message)
         end
       else

--- a/lib/grntest/test-runner.rb
+++ b/lib/grntest/test-runner.rb
@@ -590,7 +590,7 @@ http {
 
     def normalize_output_structured(type, content, options)
       response = nil
-      content = content.chomp
+      content = content.chomp unless type == "msgpack"
       if type == "json" and /\A([^(]+\()(.+)(\);)\z/ =~ content
         jsonp = true
         jsonp_start = $1
@@ -602,7 +602,7 @@ http {
       begin
         response = ResponseParser.parse(content, type)
       rescue ParseError
-        return $!.message
+        return $!.message + "\n"
       end
 
       if response.is_a?(Hash)


### PR DESCRIPTION
`--output-type msgpack` を使った時に、エラーで終了しないようにしました。

- `chomp`でMessagePack自体のデータを削ってしまうのを修正
- `MessagePack.unpack()`から出てくるエラーを捕捉。
- query log に不要な `--output_type "msgpack"` が入らないように修正
- エラーメッセージの`content`がバイナリなので、とりあえず`content.inspect`で読めるように修正

テストの書き方がよくわからないので、テストは追加してません。
Lubuntu 19 と Windows 7 で groonga 9.0.4 を使って動作確認はしました。
(windowsのgroongaは、出力をバイナリモードにする修正を加えて確認)