### PR TITLE
groonga-httpd: Accept long query

### DIFF
--- a/lib/grntest/test-runner.rb
+++ b/lib/grntest/test-runner.rb
@@ -547,6 +547,8 @@ http {
                      groonga on;
                      client_max_body_size 500m;
             }
+            client_header_buffer_size 64k;
+            large_client_header_buffers 4 64k;
      }
 }
         HTTP


### PR DESCRIPTION
This is a patch for avoid https://github.com/groonga/groonga/pull/1313#issuecomment-1011269992.
The issue above was caused by the query exceeding 8k, so I have extended header_buffers from 8k (default) to 64k.