### PR TITLE
Detect a memory leak as a test failure

### DIFF
--- a/lib/grntest/worker.rb
+++ b/lib/grntest/worker.rb
@@ -35,6 +35,10 @@ module Grntest
       @failed_tests.size
     end
 
+    def n_leaked_tests
+      @n_leaked_tests
+    end
+
     def on_test_finish
       @n_tests += 1
     end
@@ -181,6 +185,7 @@ module Grntest
 
           runner = TestRunner.new(@tester, self)
           return true if runner.run
+          return false if @result.n_leaked_tests > 0
 
           if n < @tester.n_retries and not interruptted?
             @result.cancel_test_failure(test_name)


### PR DESCRIPTION
Normally, grntest detect a memory leak as a test failure. However, grntest may return success even if grntest detect memory leak if we specify the --n-retries option.
Because grntest return success when a test successful even once while retry test.

I modification that grntest return false when a test fail cause of memory leak even once in this PR.