### PR TITLE
run_groonga: Change to not terminate by exception if run_groonga_xxx throws an exception

### DIFF
--- a/lib/grntest/test-runner.rb
+++ b/lib/grntest/test-runner.rb
@@ -412,15 +412,17 @@ call (int)chdir("#{context.temporary_directory_path}")
 
     def run_groonga_http(context)
       host = "127.0.0.1"
-      port = decide_groonga_server_port(host)
       pid_file_path = context.temporary_directory_path + "groonga.pid"
 
       env = extract_custom_env(context)
       spawn_options = {}
-      command_line = groonga_http_command(host, port, pid_file_path, context,
-                                          spawn_options)
+
       pid = nil
+      n_retries = 0
       begin
+        port = decide_groonga_server_port(host)
+        command_line = groonga_http_command(host, port, pid_file_path, context,
+                                            spawn_options)
         pid = Process.spawn(env, *command_line, spawn_options)
         executor = nil
         begin
@@ -446,6 +448,11 @@ call (int)chdir("#{context.temporary_directory_path}")
             end
           end
         end
+      rescue
+        sleep(0.1)
+        n_retries += 1
+        retry if n_retries < 5
+        raise
       ensure
         if pid
           begin

--- a/lib/grntest/test-runner.rb
+++ b/lib/grntest/test-runner.rb
@@ -210,11 +210,15 @@ module Grntest
 
       catch do |tag|
         context.abort_tag = tag
-        case @tester.interface
-        when "stdio"
-          run_groonga_stdio(context, &block)
-        when "http"
-          run_groonga_http(context, &block)
+        begin
+          case @tester.interface
+          when "stdio"
+            run_groonga_stdio(context, &block)
+          when "http"
+            run_groonga_http(context, &block)
+          end
+        rescue => error
+          $stderr.puts("#{error.class}: #{error}")
         end
       end
     end
@@ -446,9 +450,6 @@ call (int)chdir("#{context.temporary_directory_path}")
             end
           end
         end
-      rescue Grntest::Error => error
-        $stderr.puts("#{error.class}: #{error}")
-        return
       ensure
         if pid
           begin


### PR DESCRIPTION
Currently, `run_groonga_http` throws an exception and terminates there.
That is why retry by `--n-retries` option is not working.

With this change, the test result is empty and the test fails.
If `--n-retries` is specified, it will be retried.

GitHub Actions often fail. If it fails, it is the following error:
```
nginx: [emerg] bind() to 0.0.0.0:50042 failed (98: Address already in use)
nginx: [emerg] still could not bind()
/var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:185:in `rescue in run_http_request': failed to read response from Groonga: <http://127.0.0.1:50042/d/status>: Failed to open TCP connection to 127.0.0.1:50042 (Connection refused - connect(2) for "127.0.0.1" port 50042) (Grntest::Error)
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:180:in `run_http_request'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:158:in `block in send_normal_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:157:in `send_normal_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:57:in `send_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:64:in `ensure_groonga_ready'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:429:in `run_groonga_http'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:217:in `block in run_groonga'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:211:in `catch'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:211:in `run_groonga'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:174:in `block in execute_groonga_script'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:191:in `create_temporary_directory'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:143:in `execute_groonga_script'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:114:in `block in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:113:in `run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:181:in `block in run_test'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:177:in `loop'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:177:in `run_test'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:106:in `block (2 levels) in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:96:in `loop'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:96:in `block in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:94:in `run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-suites-runner.rb:129:in `block (2 levels) in run_test_suites'
/usr/lib/ruby/3.2.0/net/http.rb:1603:in `initialize': Failed to open TCP connection to 127.0.0.1:50042 (Connection refused - connect(2) for "127.0.0.1" port 50042) (Errno::ECONNREFUSED)
	from /usr/lib/ruby/3.2.0/net/http.rb:1603:in `open'
	from /usr/lib/ruby/3.2.0/net/http.rb:1603:in `block in connect'
	from /usr/lib/ruby/3.2.0/timeout.rb:189:in `block in timeout'
	from /usr/lib/ruby/3.2.0/timeout.rb:196:in `timeout'
	from /usr/lib/ruby/3.2.0/net/http.rb:1601:in `connect'
	from /usr/lib/ruby/3.2.0/net/http.rb:1580:in `do_start'
	from /usr/lib/ruby/3.2.0/net/http.rb:1569:in `start'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:161:in `block (2 levels) in send_normal_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:182:in `run_http_request'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:158:in `block in send_normal_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:157:in `send_normal_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:57:in `send_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:64:in `ensure_groonga_ready'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:429:in `run_groonga_http'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:217:in `block in run_groonga'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:211:in `catch'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:211:in `run_groonga'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:174:in `block in execute_groonga_script'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:191:in `create_temporary_directory'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:143:in `execute_groonga_script'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:114:in `block in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:113:in `run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:181:in `block in run_test'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:177:in `loop'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:177:in `run_test'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:106:in `block (2 levels) in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:96:in `loop'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:96:in `block in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:94:in `run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-suites-runner.rb:129:in `block (2 levels) in run_test_suites'
/usr/lib/ruby/3.2.0/net/http.rb:1603:in `initialize': Connection refused - connect(2) for "127.0.0.1" port 50042 (Errno::ECONNREFUSED)
	from /usr/lib/ruby/3.2.0/net/http.rb:1603:in `open'
	from /usr/lib/ruby/3.2.0/net/http.rb:1603:in `block in connect'
	from /usr/lib/ruby/3.2.0/timeout.rb:189:in `block in timeout'
	from /usr/lib/ruby/3.2.0/timeout.rb:196:in `timeout'
	from /usr/lib/ruby/3.2.0/net/http.rb:1601:in `connect'
	from /usr/lib/ruby/3.2.0/net/http.rb:1580:in `do_start'
	from /usr/lib/ruby/3.2.0/net/http.rb:1569:in `start'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:161:in `block (2 levels) in send_normal_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:182:in `run_http_request'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:158:in `block in send_normal_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:157:in `send_normal_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:57:in `send_command'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/executors/http-executor.rb:64:in `ensure_groonga_ready'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:429:in `run_groonga_http'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:217:in `block in run_groonga'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:211:in `catch'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:211:in `run_groonga'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:174:in `block in execute_groonga_script'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:191:in `create_temporary_directory'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:143:in `execute_groonga_script'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:114:in `block in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-runner.rb:113:in `run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:181:in `block in run_test'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:177:in `loop'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:177:in `run_test'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:106:in `block (2 levels) in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:96:in `loop'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:96:in `block in run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/base-result.rb:28:in `measure'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/worker.rb:94:in `run'
	from /var/lib/gems/3.2.0/gems/grntest-1.8.0/lib/grntest/test-suites-runner.rb:129:in `block (2 levels) in run_test_suites'
```