### PR TITLE
Use `context.result` instead of `$stderr.puts`

### DIFF
--- a/lib/grntest/test-runner.rb
+++ b/lib/grntest/test-runner.rb
@@ -218,7 +218,7 @@ module Grntest
             run_groonga_http(context, &block)
           end
         rescue => error
-          $stderr.puts("#{error.class}: #{error}")
+          context.result << [:error, "#{error.class}: #{error}", {}]
         end
       end
     end


### PR DESCRIPTION
It is easier to understand the output when a test fails.