### PR TITLE
Update the minimum version of json

### DIFF
--- a/grntest.gemspec
+++ b/grntest.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("groonga-log")
   spec.add_runtime_dependency("groonga-query-log", ">= 1.4.1")
   spec.add_runtime_dependency("groonga-synonym")
-  spec.add_runtime_dependency("json", ">= 2.8.1")
+  spec.add_runtime_dependency("json", ">= 2.11.3")
   spec.add_runtime_dependency("msgpack")
   spec.add_runtime_dependency("rexml")
 


### PR DESCRIPTION
The format of float has changed since json 2.11.0.

* Before: `1.0e-06`
* After:  `0.000001`

Update the minimum version of json to be unified with the latest format.

The latest at the time of this change was 2.11.3, so that is what was specified.