### PR TITLE
ci: Remove unnecessary GCC upgrades

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,20 +27,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Update MSYS2
-        run: |
-          ridk exec pacman --sync --refresh --sysupgrade --sysupgrade --noconfirm
-          taskkill /F /FI "MODULES eq msys-2.0.dll"
-          ridk exec pacman --sync --refresh
-      - name: Update GCC
-        run: |
-          ridk exec pacman --remove --noconfirm --unneeded `
-            mingw-w64-x86_64-gcc-ada `
-            mingw-w64-x86_64-gcc-fortran `
-            mingw-w64-x86_64-gcc-libgfortran `
-            mingw-w64-x86_64-gcc-objc `
-            mingw-w64-x86_64-libgccjit
-          ridk exec pacman --sync --noconfirm mingw-w64-x86_64-gcc
       - name: Install dependencies
         run: |
           bundle install


### PR DESCRIPTION
This also fixes GCC 15 related errors because we don't upgrade GCC to 15 by removed configuration.
See also: https://bugs.ruby-lang.org/issues/21286