### PR TITLE
ci windows: drop support for Ruby 2.7, 3.0, and 3.1

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,9 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7"
-          - "3.0"
-          - "3.1"
           - "3.2"
           - "3.3"
     runs-on: windows-latest


### PR DESCRIPTION
Because they have been already reached EOL.
ref: https://www.ruby-lang.org/en/downloads/branches/